### PR TITLE
Fix Match Stats Mobile View

### DIFF
--- a/get5/static/css/get5.css
+++ b/get5/static/css/get5.css
@@ -24,4 +24,9 @@ ul.nav.navbar-nav {
 		float:none;
 		text-align:center;
 	}
+	.panel-body
+	{
+		float:none;
+		overflow-x:scroll;
+	}
 }


### PR DESCRIPTION
It was going out of the mobile view section and going out of table area. Simple fix of adding scroll bar.