### PR TITLE
Remove enum after EOL of Python2.7 crash

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ colorama==0.3.7
 configparser==3.5.0
 coverage==4.1
 docopt==0.6.2
-enum==0.4.6
 enum34==1.1.6
 flake8==3.2.1
 Flask==1.0


### PR DESCRIPTION
Enum is no longer working after Python 2.7 EOL. This is should atleast bring some workaround for all the panel installation.